### PR TITLE
[#51] - Visualizar entradas del evento activo en el dashboard

### DIFF
--- a/scripts/set-environment.ts
+++ b/scripts/set-environment.ts
@@ -49,4 +49,5 @@ writeFile(targetPath, environmentFileContent, { flag: 'w' }, function (err: Errn
     console.log('-------- | Domain      : ', process.env['AUTH0_DOMAIN']);
     console.log('-------- | Redirect URI: ', process.env['AUTH0_REDIRECT_URI']);
     console.log('-------- | Client ID   : ', process.env['AUTH0_CLIENT_ID']);
+    console.log('-------- | Evento Activo ID   : ', process.env['SELECTED_EVENT_ID']);
 });

--- a/src/api/ticket/ticket.controller.ts
+++ b/src/api/ticket/ticket.controller.ts
@@ -33,7 +33,14 @@ function getByUUID(req: Request, res: Response, next: NextFunction) {
 }
 
 function getAll(req: Request, res: Response, next: NextFunction) {
-    ticketService.getAll()
+    const idEvent = req.query['idEvent'] as string;
+    console.log(idEvent);
+    if(!idEvent){
+        res.status(400).send('idEvent is required');
+        return
+    }
+
+    ticketService.getAll(parseInt(idEvent))
         .then((tickets) => res.status(200).json(tickets))
         .catch((err) => next(err))
 }

--- a/src/api/ticket/ticket.service.ts
+++ b/src/api/ticket/ticket.service.ts
@@ -16,8 +16,12 @@ export async function getByUUID(uuid: string) {
     return db.query.ticket.findFirst({ with: { event: true }, where: eq(ticketSchemas.ticket.qrString, uuid) })
 }
 
-export async function getAll() {
-    return db.query.ticket.findMany({ with: { event: true } });
+/**
+ * Obtiene todos los tickets del evento activl actual
+ * @param idEvent
+ */
+export async function getAll(idEvent: number) {
+    return db.query.ticket.findMany({ with: { event: true }, where: eq(ticketSchemas.ticket.idEvent, idEvent) });
 }
 
 export async function create({ cost, firstName, lastName, email, phone, dni, createdBy, event }: any) {

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -1,9 +1,13 @@
 import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { TicketService } from '../../providers/ticket.service'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { RouterLink } from '@angular/router'
 import { ROUTE_TREE } from '../../app.routes'
+import { switchMap } from 'rxjs';
+
+// Services
+import { EventService } from '../../providers/event.service';
+import { TicketService } from '../../providers/ticket.service'
 
 @Component({
 	selector: 'ticketera-dashboard',
@@ -60,6 +64,9 @@ export class DashboardComponent {
 
 	appRoute = ROUTE_TREE;
 
+	private eventService = inject(EventService);
 	private ticketService = inject(TicketService);
-	tickets$ = this.ticketService.getAllTickets().pipe(takeUntilDestroyed());
+	tickets$ = this.eventService.selectedEvent$.asObservable().pipe(
+		switchMap((event) => this.ticketService.getAllTickets(event!.id)),
+		takeUntilDestroyed());
 }

--- a/src/app/providers/event.service.ts
+++ b/src/app/providers/event.service.ts
@@ -8,12 +8,14 @@ import { environment } from '../environments/environment'
   providedIn: 'root'
 })
 export class EventService {
+  private readonly prefix = `${environment.redirectUri}api/event`;
+
   selectedEvent$ = new BehaviorSubject<Event | null>(null);
 
   http = inject(HttpClient);
 
   getById(id: number): Observable<Event> {
-    return this.http.get<Event>(`${environment.redirectUri}/api/event/${id}`);
+    return this.http.get<Event>(`${this.prefix}/${id}`);
   }
 
   // Asigna un evento por defecto para la aplicación

--- a/src/app/providers/ticket.service.ts
+++ b/src/app/providers/ticket.service.ts
@@ -10,7 +10,7 @@ import { environment } from '../environments/environment'
 })
 export class TicketService {
 	private http = inject(HttpClient);
-	private readonly prefix = `/api/ticket`;
+	private readonly prefix = `${environment.redirectUri}api/ticket`;
 
 	getTicketByID(id: number): Observable<Ticket> {
 		return this.http.get<Ticket>(`${this.prefix}/${id}`);
@@ -20,8 +20,8 @@ export class TicketService {
 		return this.http.get<Ticket>(`${this.prefix}/uuid/${uuid}`);
 	}
 
-	getAllTickets(): Observable<Ticket[]> {
-		return this.http.get<Ticket[]>(`${this.prefix}`);
+	getAllTickets(idEvent: number): Observable<Ticket[]> {
+		return this.http.get<Ticket[]>(`${this.prefix}?idEvent=${idEvent}`);
 	}
 
 	createTicket(ticket: Ticket): Observable<Ticket> {


### PR DESCRIPTION
## Resumen

### Backend
- Agrega procesamiento del queryParam idEvent en el endpoint `/api/ticket`, a fin de obtener sólo los tickets del evento activo actual.
- Modifica query de Drizzle para filtrar lista de tickets en base al evento pasado como parámetro a la función `ticketService.getAll()`

### Frontend
- Agrega `idEvent` como queryParam de la request del método `getAllTickets`.
- Modifica prefixes para requests HTTP en `EventService` y `TicketService`, usando URL del host y el prefijo del recurso de la API.

## Otros cambios
- Imprime en consola el ID del evento activo definido en `.env`