### PR TITLE
[#26] - fix - Dirección del evento

### DIFF
--- a/src/app/pages/ticket-detail/ticket-detail.component.ts
+++ b/src/app/pages/ticket-detail/ticket-detail.component.ts
@@ -24,8 +24,8 @@ import { Ticket } from '../../interfaces/ticket.model';
 				</div>
 				<div class="mt-5 grid grid-cols-2">
 					<div class="text-left">
-						{{selectedEvent$.value?.startDate | date: 'dd/MM/yyyy' : 'GMT-3' }} <br />
-						{{selectedEvent$.value?.startDate | date: 'h:mm a' : 'GMT-3' }}
+						{{selectedEvent$.value?.startDate | date: 'dd/MM/yyyy' }} <br />
+						{{selectedEvent$.value?.startDate | date: 'h:mm a' }}
 					</div>
 					<div class="text-right"><span class="font-bold">{{selectedEvent$.value?.venueName}}</span><br />{{selectedEvent$.value?.venueAddress}}</div>
 				</div>

--- a/src/app/pages/ticket-detail/ticket-detail.component.ts
+++ b/src/app/pages/ticket-detail/ticket-detail.component.ts
@@ -2,6 +2,7 @@ import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { QRCodeModule } from 'angularx-qrcode';
 import { TicketService } from 'src/app/providers/ticket.service';
+import { EventService } from 'src/app/providers/event.service';
 import { ActivatedRoute } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { map, Observable, switchMap } from 'rxjs';
@@ -16,17 +17,17 @@ import { Ticket } from '../../interfaces/ticket.model';
 		@if (ticket$ | async; as ticket) {
 			<div class="m-5 grid rounded bg-white p-5 text-center drop-shadow">
 				<div class="flex justify-between">
-					<p class="text-xl font-bold">EVENTO PRIVADO</p>
+					<p class="text-xl font-bold">{{selectedEvent$.value?.name}}</p>
 					<span class="whitespace-nowrap rounded-full bg-gray-100 px-2.5 py-0.5 text-sm text-gray-700">
 						Entrada #{{ ticket?.id }}
 					</span>
 				</div>
 				<div class="mt-5 grid grid-cols-2">
 					<div class="text-left">
-						28/09/2024 <br />
-						23:59
+						{{selectedEvent$.value?.startDate | date: 'dd/MM/yyyy' : 'GMT-3' }} <br />
+						{{selectedEvent$.value?.startDate | date: 'h:mm a' : 'GMT-3' }}
 					</div>
-					<div class="text-right"><span class="font-bold">Cabañas Motivos</span><br />C. 92, Arroyo Leyes</div>
+					<div class="text-right"><span class="font-bold">{{selectedEvent$.value?.venueName}}</span><br />{{selectedEvent$.value?.venueAddress}}</div>
 				</div>
 				<qrcode [qrdata]="ticket.qrString" [width]="256" [errorCorrectionLevel]="'M'" class="mx-auto"></qrcode>
 				<p class="text-2xl font-bold">{{ ticket?.lastName?.toUpperCase() }}, {{ ticket?.firstName }}</p>
@@ -49,10 +50,13 @@ export class TicketDetailComponent {
 
 	private route = inject(ActivatedRoute);
 	private ticketService = inject(TicketService);
+	private eventService = inject(EventService);
 
 	ticket$: Observable<Ticket & { whatsappUrl: string }> = this.route.params.pipe(
 		takeUntilDestroyed(),
 		switchMap(({ id }) => this.ticketService.getTicketByID(id)),
 		map((ticket) => ({ ...ticket, whatsappUrl: this.ticketService.generateTicketWhatsappURL(ticket) })),
 	);
+
+	selectedEvent$ = this.eventService.selectedEvent$
 }

--- a/src/app/pages/ticket-view/ticket-view.component.ts
+++ b/src/app/pages/ticket-view/ticket-view.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { map, switchMap } from 'rxjs'
 import { QRCodeModule } from 'angularx-qrcode';
+import { EventService } from 'src/app/providers/event.service';
 
 
 @Component({
@@ -15,17 +16,23 @@ import { QRCodeModule } from 'angularx-qrcode';
   @if(ticket$ | async; as ticket){
 	<div #ticket>
 		<div class="m-5 grid rounded bg-primary-dark text-white p-5 text-center drop-shadow">
-			<img class="w-[300px] mx-auto" src="/assets/img/evento-privado.png" alt="">
+			<img class="w-[300px] mx-auto" [src]="selectedEvent$.value?.imageUrl" alt="">
 			<hr class="my-4">
 			<div class="flex justify-between">
-				<p class="font-bold text-xl">EVENTO PRIVADO</p>
+				<p class="font-bold text-xl">{{selectedEvent$.value?.name}}</p>
 				<span class="whitespace-nowrap rounded-full bg-gray-100 px-2.5 py-0.5 text-sm text-gray-700">
 			Entrada #{{ ticket?.id }}
 			</span>
 			</div>
 			<div class="grid grid-cols-2 mt-5">
-				<div class="text-left">28/09/2024 <br> 23:59</div>
-				<div class="text-right"><span class="font-bold">Cabañas Motivos</span><br>C. 92, Arroyo Leyes</div>
+				<div class="text-left">
+					{{selectedEvent$.value?.startDate | date: 'dd/MM/yyyy' : 'GMT-3' }} <br>
+					{{selectedEvent$.value?.startDate | date: 'h:mm a' : 'GMT-3' }}
+				</div>
+				<div class="text-right"><span class="font-bold">
+					{{selectedEvent$.value?.venueName}}</span><br>
+					{{selectedEvent$.value?.venueAddress}}
+				</div>
 			</div>
 			<img class="mx-auto rounded drop-shadow" [src]="ticket.qrUrl" alt="">
 			<!--
@@ -45,10 +52,13 @@ import { QRCodeModule } from 'angularx-qrcode';
 export class TicketViewComponent {
 	private route = inject(ActivatedRoute)
 	private ticketService = inject(TicketService)
+	private eventService = inject(EventService);
 	
 	ticket$ = this.route.params.pipe(
 		takeUntilDestroyed(),
 		switchMap(({ uuid }) => this.ticketService.getTicketByUUID(uuid)),
 		map((ticket) => ({ ...ticket, qrUrl: this.ticketService.generateTicketQRURL(ticket) })),
 	);
+
+	selectedEvent$ = this.eventService.selectedEvent$
 }

--- a/src/app/providers/ticket.service.ts
+++ b/src/app/providers/ticket.service.ts
@@ -29,7 +29,7 @@ export class TicketService {
 	}
 
 	generateTicketWhatsappURL(ticket: Ticket): string {
-		return `https://api.whatsapp.com/send/?phone=549${ticket.phone}&text=HOLA+${ticket.firstName}+${ticket.lastName}+Tu+entrada+para+%2AEVENTO+PRIVADO%2A%0A%0ALink%3A+${environment.redirectUri}/ticket-view/${ticket.qrString}&type=phone_number&app_absent=0`;
+		return `https://api.whatsapp.com/send/?phone=549${ticket.phone}&text=HOLA+${ticket.firstName}+${ticket.lastName}+Tu+entrada+para+%2APAREN+LAS+TECLAS%2A%0A%0ALink%3A+${environment.redirectUri}/ticket-view/${ticket.qrString}&type=phone_number&app_absent=0`;
 	}
 
 	generateTicketQRURL(ticket: Ticket): string {


### PR DESCRIPTION
Se corrigió el modelo de `ticket-view` y `ticket-detail` para que lean dinámicamente los datos del evento seleccionado.

Se incluye un hotfix para cambiar el string de WhatsApp para el próximo evento