### PR TITLE
[#56] - Elimina uso de selectedEvent$ en vistas ticket-view y ticket-detail

### DIFF
--- a/src/app/pages/ticket-detail/ticket-detail.component.ts
+++ b/src/app/pages/ticket-detail/ticket-detail.component.ts
@@ -2,7 +2,6 @@ import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { QRCodeModule } from 'angularx-qrcode';
 import { TicketService } from 'src/app/providers/ticket.service';
-import { EventService } from 'src/app/providers/event.service';
 import { ActivatedRoute } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { map, Observable, switchMap } from 'rxjs';
@@ -17,21 +16,21 @@ import { Ticket } from '../../interfaces/ticket.model';
 		@if (ticket$ | async; as ticket) {
 			<div class="m-5 grid rounded bg-white p-5 text-center drop-shadow">
 				<div class="flex justify-between">
-					<p class="text-xl font-bold">{{selectedEvent$.value?.name}}</p>
+					<p class="text-xl font-bold">{{ticket.event.name}}</p>
 					<span class="whitespace-nowrap rounded-full bg-gray-100 px-2.5 py-0.5 text-sm text-gray-700">
 						Entrada #{{ ticket?.id }}
 					</span>
 				</div>
 				<div class="mt-5 grid grid-cols-2">
 					<div class="text-left">
-						{{selectedEvent$.value?.startDate | date: 'dd/MM/yyyy' }} <br />
-						{{selectedEvent$.value?.startDate | date: 'h:mm a' }}
+						{{ticket.event.startDate | date: 'dd/MM/yyyy' }} <br />
+						{{ticket.event.startDate | date: 'h:mm a' }}
 					</div>
-					<div class="text-right"><span class="font-bold">{{selectedEvent$.value?.venueName}}</span><br />{{selectedEvent$.value?.venueAddress}}</div>
+					<div class="text-right"><span class="font-bold">{{ticket.event.venueName}}</span><br />{{ticket.event.venueAddress}}</div>
 				</div>
 				<qrcode [qrdata]="ticket.qrString" [width]="256" [errorCorrectionLevel]="'M'" class="mx-auto"></qrcode>
-				<p class="text-2xl font-bold">{{ ticket?.lastName?.toUpperCase() }}, {{ ticket?.firstName }}</p>
-				<p class="text-2xl font-bold">{{ ticket?.dni }}</p>
+				<p class="text-2xl font-bold">{{ ticket.lastName.toUpperCase() }}, {{ ticket.firstName }}</p>
+				<p class="text-2xl font-bold">{{ ticket.dni }}</p>
 				<a [href]="ticket.whatsappUrl" target="_blank">
 					<button
 						class="mt-5 flex w-full justify-center rounded bg-success px-4 py-2 font-bold text-white drop-shadow hover:bg-success-dark"
@@ -50,13 +49,10 @@ export class TicketDetailComponent {
 
 	private route = inject(ActivatedRoute);
 	private ticketService = inject(TicketService);
-	private eventService = inject(EventService);
 
 	ticket$: Observable<Ticket & { whatsappUrl: string }> = this.route.params.pipe(
 		takeUntilDestroyed(),
 		switchMap(({ id }) => this.ticketService.getTicketByID(id)),
 		map((ticket) => ({ ...ticket, whatsappUrl: this.ticketService.generateTicketWhatsappURL(ticket) })),
 	);
-
-	selectedEvent$ = this.eventService.selectedEvent$
 }

--- a/src/app/pages/ticket-view/ticket-view.component.ts
+++ b/src/app/pages/ticket-view/ticket-view.component.ts
@@ -2,11 +2,10 @@ import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TicketService } from 'src/app/providers/ticket.service';
 import { ActivatedRoute } from '@angular/router';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { map, switchMap } from 'rxjs'
+import { map, Observable, switchMap } from 'rxjs'
 import { QRCodeModule } from 'angularx-qrcode';
-import { EventService } from 'src/app/providers/event.service';
-
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
+import { Ticket } from '../../interfaces/ticket.model'
 
 @Component({
 	selector: 'ticketera-ticket-view',
@@ -16,22 +15,22 @@ import { EventService } from 'src/app/providers/event.service';
   @if(ticket$ | async; as ticket){
 	<div #ticket>
 		<div class="m-5 grid rounded bg-primary-dark text-white p-5 text-center drop-shadow">
-			<img class="w-[300px] mx-auto" [src]="selectedEvent$.value?.imageUrl" alt="">
+			<img class="w-[300px] mx-auto" [src]="ticket.event.imageUrl" alt="">
 			<hr class="my-4">
 			<div class="flex justify-between">
-				<p class="font-bold text-xl">{{selectedEvent$.value?.name}}</p>
+				<p class="font-bold text-xl">{{ticket.event.name}}</p>
 				<span class="whitespace-nowrap rounded-full bg-gray-100 px-2.5 py-0.5 text-sm text-gray-700">
 			Entrada #{{ ticket?.id }}
 			</span>
 			</div>
 			<div class="grid grid-cols-2 mt-5">
 				<div class="text-left">
-					{{selectedEvent$.value?.startDate | date: 'dd/MM/yyyy' : 'GMT-3' }} <br>
-					{{selectedEvent$.value?.startDate | date: 'h:mm a' : 'GMT-3' }}
+					{{ticket.event.startDate | date: 'dd/MM/yyyy' : 'GMT-3' }} <br>
+					{{ticket.event.startDate | date: 'h:mm a' : 'GMT-3' }}
 				</div>
 				<div class="text-right"><span class="font-bold">
-					{{selectedEvent$.value?.venueName}}</span><br>
-					{{selectedEvent$.value?.venueAddress}}
+					{{ticket.event.venueName}}</span><br>
+					{{ticket.event.venueAddress}}
 				</div>
 			</div>
 			<img class="mx-auto rounded drop-shadow" [src]="ticket.qrUrl" alt="">
@@ -39,8 +38,8 @@ import { EventService } from 'src/app/providers/event.service';
 				TODO: revisar qrcode para que funcione
 				<qrcode class="mx-auto rounded drop-shadow" [qrdata]="ticket.qrString" [width]="256" [errorCorrectionLevel]="'M'"></qrcode>
 			-->
-			<p class="text-2xl font-bold">{{ ticket?.lastName?.toUpperCase() }}, {{ ticket?.firstName }}</p>
-			<p class="text-2xl font-bold">{{ ticket?.dni }}</p>
+			<p class="text-2xl font-bold">{{ ticket.lastName.toUpperCase() }}, {{ ticket.firstName }}</p>
+			<p class="text-2xl font-bold">{{ ticket.dni }}</p>
 			
 		</div>
 
@@ -52,13 +51,10 @@ import { EventService } from 'src/app/providers/event.service';
 export class TicketViewComponent {
 	private route = inject(ActivatedRoute)
 	private ticketService = inject(TicketService)
-	private eventService = inject(EventService);
-	
-	ticket$ = this.route.params.pipe(
+
+	ticket$: Observable<Ticket & { qrUrl: string }>  = this.route.params.pipe(
 		takeUntilDestroyed(),
 		switchMap(({ uuid }) => this.ticketService.getTicketByUUID(uuid)),
 		map((ticket) => ({ ...ticket, qrUrl: this.ticketService.generateTicketQRURL(ticket) })),
 	);
-
-	selectedEvent$ = this.eventService.selectedEvent$
 }


### PR DESCRIPTION
## Resumen
Reemplaza uso de `selectedEvent$` por el uso de la propiedad `event` contenida dentro de los objetos de tipo `Ticket`, lo cual permite depender de la suscripción a un único observable para visualizar la información del ticket y del evento al que pertenece en las vistas `ticket-view` y `ticket-detail`